### PR TITLE
Example StreamResource that emit Emit Html in chunks.

### DIFF
--- a/htmlflow-dev/pom.xml
+++ b/htmlflow-dev/pom.xml
@@ -59,6 +59,11 @@
             <version>4.8-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.reactivex.rxjava3</groupId>
+            <artifactId>rxjava</artifactId>
+            <version>3.1.10</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/htmlflow-dev/src/main/java/com/dev/StreamResource.java
+++ b/htmlflow-dev/src/main/java/com/dev/StreamResource.java
@@ -1,0 +1,84 @@
+package com.dev;
+
+import io.reactivex.rxjava3.core.Observable;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PipedReader;
+import java.io.PipedWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+@Path("/html-chunked")
+public class StreamResource {
+
+    private static long timeout = 1000;
+    static final Observable<String> model = Observable
+            .fromArray("CR7", "Lebron James", "Stephen Curry", "Nigel Mansel", "Rossi")
+            .concatMap(item -> Observable.just(item).delay(timeout, TimeUnit.MILLISECONDS));
+
+    public static void viewTopScores(Writer writer) throws IOException {
+        writer.write("<table><thead><tr><th>Top Scorers</th></tr></thead>");
+        writer.write("<tbody>");
+        writer.flush();
+        model.blockingForEach(item -> {
+            writer.write("<tr><td>" + item + "</td></tr>");
+            writer.flush();
+        });
+        writer.write("</tbody></table>");
+        writer.flush();
+        writer.close();
+    }
+
+    @Path("/writer")
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    public Reader getHtml() throws IOException {
+        return buildReaderFromWriterBlock(writer -> {
+            try {
+                viewTopScores(writer);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+    }
+
+    @Path("/stream")
+    @GET
+    @Produces(MediaType.TEXT_HTML)  // Can be JSON, plain text, etc.
+    public Response streamResponse() {
+        StreamingOutput stream = (OutputStream output) -> {
+            viewTopScores(new OutputStreamWriter(output));
+        };
+        return Response.ok(stream).build();
+    }
+
+
+    private static Reader buildReaderFromWriterBlock(Consumer<Writer> block) throws IOException {
+        PipedWriter writer = new PipedWriter();
+        PipedReader reader = new PipedReader(writer); // Connect the reader to the writer
+        Thread writerThread = new Thread(() -> {
+            block.accept(writer);
+        });
+        writerThread.start();
+        return reader;
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/htmlflow-dev/src/main/resources/application.properties
+++ b/htmlflow-dev/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.rest.output-buffer-size=8


### PR DESCRIPTION
Two ways of sending HTML in chunks. Both examples just use hard-coded HTML without templates.

But both examples are easily converted into an HtmlFlow template, since they only depend of a java `Writer`. Note that a `Writer` is an `Appendable` which is a valid output for an `HtmlView` using `view.setOut(writer).write(model)`.

Moreover, to observe HTML in chunks we need to reduce the size of the output buffer which I modified in `application.properties` through: `quarkus.rest.output-buffer-size=8`.

Also this example uses a model from an RxJava Observable which includes a delay of 1 second interleaving items.